### PR TITLE
Save on PUT; fixes user/admin permissions

### DIFF
--- a/api/permissions.py
+++ b/api/permissions.py
@@ -11,3 +11,21 @@ class IsOwnerOrReadOnly(permissions.BasePermission):
             return True
         # Write permissions are only allowed to the owner of the snippet.
         return (obj.owner == request.user or request.user.is_staff)
+
+class IsUserOrReadOnly(permissions.BasePermission):
+    """
+    Custom permission to only allow user to update own object
+    """
+    def has_permission(self, request, view):
+        # allow user to list all users if logged in user is staff
+        if view.action in ['retrieve', 'update', 'destroy']:
+            return True
+        return request.user.is_staff
+
+    def has_object_permission(self, request, view, obj):
+        # Read permissions are allowed to any request
+        # So we'll always allow GET, HEAD, or OPTIONS request.
+        if request.method in permissions.SAFE_METHODS:
+            return True
+        # Write permissions are only allowed to the owner of the snippet.
+        return (obj == request.user or request.user.is_staff)

--- a/api/views.py
+++ b/api/views.py
@@ -5,7 +5,7 @@ from api.serializers import UserSerializer, ReadingSerializer
 from rest_framework import status
 
 from rest_framework import permissions
-from api.permissions import IsOwnerOrReadOnly
+from api.permissions import IsOwnerOrReadOnly, IsUserOrReadOnly
 
 from rest_framework import renderers, viewsets
 from rest_framework.response import Response
@@ -61,9 +61,14 @@ class ReadingViewSet(viewsets.ModelViewSet):
 class UserViewSet(viewsets.ModelViewSet):
     queryset = User.objects.all()
     serializer_class = UserSerializer
-    permission_classes = (permissions.IsAdminUser,)
+    permission_classes = (IsUserOrReadOnly,)
 
     def perform_create(self, serializer):
+        instance = serializer.save(password = self.request.DATA['password'])
+        instance.set_password(instance.password)
+        instance.save()
+
+    def perform_update(self, serializer):
         instance = serializer.save(password = self.request.DATA['password'])
         instance.set_password(instance.password)
         instance.save()


### PR DESCRIPTION
This fixes the permissions so that only the superuser can create users. A user can now change his password via a PUT request.

Fixes #5 
